### PR TITLE
add ingress paths value

### DIFF
--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -210,5 +210,5 @@ server:
     ## Prometheus server Ingress paths
     ## Must be used for Prometheus federation
     ##
-    paths: [{"backend": {"serviceName": "prometheusfederation","servicePort": 9090},"path": '/federate'}]
+    paths: [{"backend": {"serviceName": "prometheusfederation", "servicePort": 9090}, "path": '/federate'}]
 ```

--- a/stable/prometheus/README.md
+++ b/stable/prometheus/README.md
@@ -122,6 +122,7 @@ Parameter | Description | Default
 `server.ingress.enabled` | If true, Prometheus server Ingress will be created | `false`
 `server.ingress.annotations` | Prometheus server Ingress annotations | `[]`
 `server.ingress.hosts` | Prometheus server Ingress hostnames | `[]`
+`server.ingress.paths` | Prometheus server Ingress paths | `[]`
 `server.ingress.tls` | Prometheus server Ingress TLS configuration (YAML) | `[]`
 `server.nodeSelector` | node labels for Prometheus server pod assignment | `{}`
 `server.persistentVolume.enabled` | If true, Prometheus server will create a Persistent Volume Claim | `true`
@@ -198,4 +199,16 @@ server:
       - secretName: prometheus-server-tls
         hosts:
           - prometheus.domain.com
+```
+
+### Ingress Paths
+Prometheus federation requires the source server's 'federate' endpoint to be scraped on port 9090, to define the needed Ingress paths:
+
+```
+server:
+  ingress:
+    ## Prometheus server Ingress paths
+    ## Must be used for Prometheus federation
+    ##
+    paths: [{"backend": {"serviceName": "prometheusfederation","servicePort": 9090},"path": '/federate'}]
 ```

--- a/stable/prometheus/templates/server-ingress.yaml
+++ b/stable/prometheus/templates/server-ingress.yaml
@@ -2,6 +2,7 @@
 {{- $releaseName := .Release.Name -}}
 {{- $serviceName := include "prometheus.server.fullname" . }}
 {{- $servicePort := .Values.server.service.servicePort -}}
+{{- $paths := .Values.server.ingress.paths -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -22,6 +23,9 @@ spec:
     - host: {{ . }}
       http:
         paths:
+{{ if $paths }}
+{{ toYaml $paths |indent 10 }}
+{{ end }}
           - backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}

--- a/stable/prometheus/values.yaml
+++ b/stable/prometheus/values.yaml
@@ -307,6 +307,11 @@ server:
     hosts: []
     #   - prometheus.domain.com
 
+    ## Prometheus server Ingress paths
+    ## Must be used for Prometheus federation
+    ##
+    paths: []
+
     ## Prometheus server Ingress TLS configuration
     ## Secrets must be manually created in the namespace
     ##


### PR DESCRIPTION
To enable prometheus federation the 'federate' endpoint needs to be reachable on port 9090, to do this you need to add a new path to the server ingress template. In this PR I add a new value for server ingress paths and if it is set then we inject the desired paths into the server ingress template.

In order to parse properly paths must be defined in JSON:

```
server:
  ingress:
    paths: [{"backend": {"serviceName": "promfed","servicePort": 9090},"path": '/federate'}]
```